### PR TITLE
MBP-16: bg color for work intro

### DIFF
--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -67,7 +67,7 @@ async function Page({ params }: { params: Promise<{ slug: string }> }) {
       <SkillsList skills={skills} />
       <ProjectHeroImage alt={heroImage.alt} src={heroImage.src} />
       {introduction && (
-        <p className="subheading1 bg-light-surface-primary">{introduction}</p>
+        <p className="subheading1">{introduction}</p>
       )}
       <div className="full-story">{fullStory}</div>
     </>


### PR DESCRIPTION
Removed bg color that was mistakenly applied to the work `introduction` element.