### PR TITLE
MBP-30: heading levels on Work page

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -61,7 +61,7 @@ const ProjectCard = (props: ProjectCardProps) => {
         <Heading
           className={styles.heading}
           fontFamily="alt"
-          level="h3"
+          level="h2"
           size="heading5"
         >
           {title}


### PR DESCRIPTION
Fixed hierarchy of heading levels on `Work` page to fix a11y issues.